### PR TITLE
TSDK-779 Connect to Bitcoind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initialized the front end for the demo application
 - Initialized the back end for the demo application
+- Connected backend to bitcoind

--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ cd ../demo-server
 sbt dev
 ```
 
-This copies the front end app into the server's resources directory, and starts the server on `localhost:3000`.
+This copies the front end app into the server's resources directory, and starts the server on `localhost:3002`.
 
-You can access the app (now connected to a backend) at `localhost:3000`.
+You can access the app (now connected to a backend) at `localhost:3002`.

--- a/demo-server/build.sbt
+++ b/demo-server/build.sbt
@@ -1,6 +1,8 @@
 import Dependencies._
 import scala.sys.process.Process
 
+lazy val scalacVersion = "2.13.12"
+
 inThisBuild(
   List(
     homepage := Some(url("https://github.com/Topl/demo-btc-wallet")),
@@ -28,9 +30,10 @@ importClient := {
 lazy val root = project
   .in(file("."))
   .settings(
+    scalaVersion := scalacVersion,
     organization := "co.topl",
     name := "topl-demo-btc-wallet",
-    libraryDependencies ++= scalaTest ++ http4s ++ cats ++ log4cats ++ slf4j ++ circe
+    libraryDependencies ++= http4s ++ cats ++ log4cats ++ slf4j ++ circe ++ btc ++ scopt
     )
     .settings(noPublish)
 

--- a/demo-server/build.sbt
+++ b/demo-server/build.sbt
@@ -38,4 +38,4 @@ lazy val root = project
     .settings(noPublish)
 
 // Development mode: reloads the server when you change the code. Use "sbt dev" to run.
-addCommandAlias("dev", "importClient ; ~reStart")
+addCommandAlias("dev", "importClient ; ~reStart --btc-user=test --btc-password=test")

--- a/demo-server/project/Dependencies.scala
+++ b/demo-server/project/Dependencies.scala
@@ -7,6 +7,7 @@ object Dependencies {
   lazy val log4catsVersion = "2.6.0"
   lazy val slf4jVersion = "2.0.12"
   lazy val circeVersion = "0.14.6"
+  lazy val btcVersion = "1.9.7"
 
   lazy val scalaTest: Seq[ModuleID] = Seq("org.scalatest" %% "scalatest" % "3.0.5" % Test)
 
@@ -36,4 +37,11 @@ object Dependencies {
     "io.circe" %% "circe-generic" % circeVersion,
     "io.circe" %% "circe-literal" % circeVersion
   )
+
+  lazy val btc: Seq[ModuleID] = Seq(
+    "org.bitcoin-s" %% "bitcoin-s-core" % btcVersion,
+    "org.bitcoin-s" %% "bitcoin-s-bitcoind-rpc" % btcVersion
+  )
+
+  lazy val scopt: Seq[ModuleID] = Seq("com.github.scopt" %% "scopt" % "4.0.1")
 }

--- a/demo-server/src/main/scala/co/topl/btc/server/Main.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/Main.scala
@@ -43,7 +43,7 @@ object Main extends IOApp {
   def runWithArgs(args: Params): IO[ExitCode] = {
     val bitcoindInstance = remoteConnection(
       RegTest, 
-      args.bitcoindHost, 
+      args.bitcoindUrl, 
       PasswordBased(args.bitcoindUser, args.bitcoindPassword)
     )
     (for {

--- a/demo-server/src/main/scala/co/topl/btc/server/Main.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/Main.scala
@@ -12,9 +12,15 @@ import cats.effect.IO
 import cats.effect.IOApp
 import cats.data.Kleisli
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import co.topl.btc.server.bitcoin.remoteConnection
+import org.bitcoins.core.config.RegTest
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.rpc.config.BitcoindAuthCredentials.PasswordBased
+import scopt.OParser
 
 import co.topl.btc.server.api.ApiService
 import org.http4s.dsl.impl.Responses
+import co.topl.btc.server.bitcoin.onStartup
 
 object Main extends IOApp {
   def webUI() = HttpRoutes.of[IO] { case request @ GET -> Root =>
@@ -24,23 +30,41 @@ object Main extends IOApp {
   }
   val router = 
     Router.define("/api" -> ApiService, "/" -> webUI())(default = resourceServiceBuilder[IO]("/static").toRoutes)
-  def run(args: List[String]): IO[ExitCode] =
-    EmberServerBuilder
-      .default[IO]
-      .withIdleTimeout(ServerConfig.idleTimeOut)
-      .withHost(ServerConfig.host)
-      .withPort(ServerConfig.port)
-      .withHttpApp(
-        Kleisli[IO, Request[IO], Response[IO]] { request =>
-          router.run(request).getOrElse(Response.notFound)
-        }
-      )
-      .withLogger(Slf4jLogger.getLogger[IO])
-      .build
-      .allocated
-      .handleErrorWith { e =>
-        e.printStackTrace()
-        IO(e.getMessage)
-      } >> (IO.println(s"Server started on ${ServerConfig.host}:${ServerConfig.port}") *> IO.never)
+
+  override def run(args: List[String]): IO[ExitCode] = Params.parseParams(args) match {
+    case Some(config) =>
+      runWithArgs(config)
+    case None =>
+      IO.consoleForIO.errorln("Invalid arguments") *>
+        IO(ExitCode.Error)
+  }
+
+  def runWithArgs(args: Params): IO[ExitCode] = {
+    val bitcoindInstance = remoteConnection(
+      RegTest, 
+      args.bitcoindHost, 
+      PasswordBased(args.bitcoindUser, args.bitcoindPassword)
+    )
+    (for {
+      _ <- onStartup(bitcoindInstance)
+      _ <- EmberServerBuilder
+        .default[IO]
+        .withIdleTimeout(ServerConfig.idleTimeOut)
+        .withHost(ServerConfig.host)
+        .withPort(ServerConfig.port)
+        .withHttpApp(
+          Kleisli[IO, Request[IO], Response[IO]] { request =>
+            router.run(request).getOrElse(Response.notFound)
+          }
+        )
+        .withLogger(Slf4jLogger.getLogger[IO])
+        .build
+        .allocated
+    } yield s"Server started on ${ServerConfig.host}:${ServerConfig.port}")
+    .handleErrorWith { e =>
+      e.printStackTrace()
+      IO(e.getMessage)
+    } >> IO.never
+  }
 
 }

--- a/demo-server/src/main/scala/co/topl/btc/server/Params.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/Params.scala
@@ -3,7 +3,7 @@ package co.topl.btc.server
 import scopt.OParser
 
 final case class Params(
-  bitcoindHost: String = "http://localhost", 
+  bitcoindUrl: String = "http://localhost", 
   bitcoindUser: String = "", 
   bitcoindPassword: String = ""
 )
@@ -14,10 +14,10 @@ object Params {
     import builder._
     OParser.sequence(
       programName("demo-btc-wallet"),
-      opt[String]("btc-host")
-        .action((x, c) => c.copy(bitcoindHost = x))
+      opt[String]("btc-url")
+        .action((x, c) => c.copy(bitcoindUrl = x))
         .text(
-          "The host to connect to a bitcoind instance. (default: http://localhost)"
+          "The URL to connect to a bitcoind instance. (default: http://localhost)"
         ),
       opt[String]("btc-user")
         .required()

--- a/demo-server/src/main/scala/co/topl/btc/server/Params.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/Params.scala
@@ -1,0 +1,38 @@
+package co.topl.btc.server
+
+import scopt.OParser
+
+final case class Params(
+  bitcoindHost: String = "http://localhost", 
+  bitcoindUser: String = "", 
+  bitcoindPassword: String = ""
+)
+
+object Params {
+  private val parser = {
+    val builder = OParser.builder[Params]
+    import builder._
+    OParser.sequence(
+      programName("demo-btc-wallet"),
+      opt[String]("btc-host")
+        .action((x, c) => c.copy(bitcoindHost = x))
+        .text(
+          "The host to connect to a bitcoind instance. (default: http://localhost)"
+        ),
+      opt[String]("btc-user")
+        .required()
+        .action((x, c) => c.copy(bitcoindUser = x))
+        .text(
+          "The username to connect to a bitcoind instance. (required)"
+        ),
+      opt[String]("btc-password")
+        .required()
+        .action((x, c) => c.copy(bitcoindPassword = x))
+        .text(
+          "The password to connect to a bitcoind instance. (required)"
+        )
+    )
+  }
+
+  def parseParams(args: List[String]): Option[Params] = OParser.parse(parser, args, Params())
+}

--- a/demo-server/src/main/scala/co/topl/btc/server/ServerConfig.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/ServerConfig.scala
@@ -18,7 +18,7 @@ object ServerConfig {
       .getOrElse(false)
 
   val port: Port = {
-    val portStr = Option(java.lang.System.getProperty("port")).getOrElse("3000")
+    val portStr = Option(java.lang.System.getProperty("port")).getOrElse("3002")
     Port
       .fromString(portStr)
       .getOrElse(throw new Exception(s"Bad port option: `${portStr}`"))

--- a/demo-server/src/main/scala/co/topl/btc/server/api/TransferRequest.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/api/TransferRequest.scala
@@ -44,9 +44,9 @@ object TransferRequest {
       */
     def handler(r: Request[IO], bitcoind: BitcoindExtended): IO[Response[IO]] = for {
       req <- r.as[TransferRequest]
-      txId <- futureToIO(bitcoind.sendToAddress(req.toAddress, req.quantity, walletNameOpt = Some(req.fromWallet)))
+      txId <- bitcoind.sendToAddressWithFees(req.toAddress, req.quantity, req.fromWallet)
       // Manually mint a new block.. will be removed in the future
-      mintAddr <- futureToIO(bitcoind.getNewAddress(MintingWallet))
+      mintAddr <- futureToIO(bitcoind.getNewAddress(walletNameOpt = Some(MintingWallet)))
       _ <- futureToIO(bitcoind.generateToAddress(1, mintAddr))
       resp <- Ok(txId.hex)
     } yield resp

--- a/demo-server/src/main/scala/co/topl/btc/server/api/TransferRequest.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/api/TransferRequest.scala
@@ -6,29 +6,49 @@ import org.http4s._
 import org.http4s.circe._
 import org.http4s.dsl.io._
 import cats.effect.IO
+import io.circe.{ Decoder, Encoder, HCursor, Json }
+
+import org.bitcoins.core.protocol.BitcoinAddress
+import org.bitcoins.core.currency.Satoshis
+import co.topl.btc.server.bitcoin.BitcoindExtended
+import co.topl.btc.server.bitcoin.Services.MintingWallet
+import co.topl.btc.server.bitcoin.BitcoindExtended.futureToIO
 
 /**
   * A case class representing a BTC transfer request
   */
-case class TransferRequest(fromWallet: String, toAddress: String, quantity: String)
+case class TransferRequest(fromWallet: String, toAddress: BitcoinAddress, quantity: Satoshis)
 
 
 object TransferRequest {
 
     /**
-      * A Circe JSON decoder for the transfer request
+      * A Circe JSON decoders for the transfer request
       */
+    implicit val decodeTransferRequest: Decoder[TransferRequest] = new Decoder[TransferRequest] {
+      final def apply(c: HCursor): Decoder.Result[TransferRequest] =
+        for {
+          fromWallet <- c.downField("fromWallet").as[String]
+          toAddress <- c.downField("toAddress").as[String]
+          quantity <- c.downField("quantity").as[Int]
+        } yield TransferRequest(fromWallet, BitcoinAddress(toAddress), Satoshis(quantity))
+    }
     implicit val decoder: EntityDecoder[IO, TransferRequest] = jsonOf[IO, TransferRequest]
 
     /**
       * An HTTP handler for the transfer request
       *
       * @param r The request to handle
+      * @param bitcoind The bitcoind instance to use
       * @return An IO monad containing the response
       */
-    def handler(r: Request[IO]): IO[Response[IO]] = for {
+    def handler(r: Request[IO], bitcoind: BitcoindExtended): IO[Response[IO]] = for {
       req <- r.as[TransferRequest]
-      resp <- Ok(s"Sent ${req.quantity} Satoshis from ${req.fromWallet} to ${req.toAddress}")
+      txId <- futureToIO(bitcoind.sendToAddress(req.toAddress, req.quantity, walletNameOpt = Some(req.fromWallet)))
+      // Manually mint a new block.. will be removed in the future
+      mintAddr <- futureToIO(bitcoind.getNewAddress(MintingWallet))
+      _ <- futureToIO(bitcoind.generateToAddress(1, mintAddr))
+      resp <- Ok(txId.hex)
     } yield resp
 
 }

--- a/demo-server/src/main/scala/co/topl/btc/server/api/package.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/api/package.scala
@@ -3,11 +3,12 @@ package co.topl.btc.server
 import org.http4s.HttpRoutes
 import org.http4s.dsl.io._
 import cats.effect.IO
+import co.topl.btc.server.bitcoin.BitcoindExtended
 
 package object api {
 
   // Define the API service routes
-  val ApiService: HttpRoutes[IO] = HttpRoutes.of[IO] {
-    case r @ POST -> Root / "transfer" => TransferRequest.handler(r)
+  def apiService(bitcoind: BitcoindExtended): HttpRoutes[IO] = HttpRoutes.of[IO] {
+    case r @ POST -> Root / "transfer" => TransferRequest.handler(r, bitcoind)
   }
 }

--- a/demo-server/src/main/scala/co/topl/btc/server/bitcoin/BitcoindExtended.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/bitcoin/BitcoindExtended.scala
@@ -4,11 +4,11 @@ import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.rpc.config.BitcoindInstance
 import play.api.libs.json.{JsArray, JsString, JsValue}
 import cats.effect.IO
+import org.bitcoins.crypto.DoubleSha256DigestBE
 
 import scala.concurrent.Future
 
 final class BitcoindExtended(impl: BitcoindInstance) extends BitcoindRpcClient(impl){
-
   import co.topl.btc.server.bitcoin.BitcoindExtended.futureToIO
 
   private def bitcoindCallRaw(

--- a/demo-server/src/main/scala/co/topl/btc/server/bitcoin/BitcoindExtended.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/bitcoin/BitcoindExtended.scala
@@ -2,11 +2,18 @@ package co.topl.btc.server.bitcoin
 
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.rpc.config.BitcoindInstance
-import play.api.libs.json.{JsArray, JsString, JsValue}
+import play.api.libs.json.{JsArray, JsString, JsValue, JsObject}
 import cats.effect.IO
 import org.bitcoins.crypto.DoubleSha256DigestBE
+import org.bitcoins.core.protocol.BitcoinAddress
+import org.bitcoins.core.currency.{Bitcoins, CurrencyUnit}
+import play.api.libs.json.Json
+import org.bitcoins.commons.serializers.JsonSerializers._
+import org.bitcoins.commons.serializers.JsonWriters._
 
 import scala.concurrent.Future
+import play.api.libs.json.JsNumber
+import play.api.libs.json.JsBoolean
 
 final class BitcoindExtended(impl: BitcoindInstance) extends BitcoindRpcClient(impl){
   import co.topl.btc.server.bitcoin.BitcoindExtended.futureToIO
@@ -28,6 +35,27 @@ final class BitcoindExtended(impl: BitcoindInstance) extends BitcoindRpcClient(i
 
   def listWalletDirs(): IO[Seq[String]] = bitcoindCallRaw("listwalletdir")
     .map(res => (res \ "result" \\ "name").map(_.as[String]).toSeq)
+
+  
+  def sendToAddressWithFees(address: BitcoinAddress, amount: CurrencyUnit, wallet: String, feeRate: Int = 1): IO[DoubleSha256DigestBE] = 
+    bitcoindCallRaw(
+      "sendtoaddress",
+      List(
+        Json.toJson(address),
+        Json.toJson(Bitcoins(amount.satoshis)),
+        Json.toJson(None), // comment
+        Json.toJson(None), // comment_to
+        Json.toJson(None), // subtractfeefromamount
+        Json.toJson(None), // replaceable
+        Json.toJson(None), // conf_target
+        Json.toJson(None), // estimate_mode  
+        Json.toJson(None), // avoid_reuse
+        JsNumber(feeRate)
+      ),
+      uriExtensionOpt = Some(walletExtension(wallet))
+    )
+    .map(res =>(res \ "result").as[String])
+    .map(DoubleSha256DigestBE.fromHex(_))
 }
 
 object BitcoindExtended {

--- a/demo-server/src/main/scala/co/topl/btc/server/bitcoin/BitcoindExtended.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/bitcoin/BitcoindExtended.scala
@@ -9,7 +9,7 @@ import scala.concurrent.Future
 
 final class BitcoindExtended(impl: BitcoindInstance) extends BitcoindRpcClient(impl){
 
-  implicit def futureToIO[T](fut: Future[T]): IO[T] = IO.fromFuture(IO(fut))
+  import co.topl.btc.server.bitcoin.BitcoindExtended.futureToIO
 
   private def bitcoindCallRaw(
     command:         String,
@@ -31,5 +31,6 @@ final class BitcoindExtended(impl: BitcoindInstance) extends BitcoindRpcClient(i
 }
 
 object BitcoindExtended {
+  implicit def futureToIO[T](fut: Future[T]): IO[T] = IO.fromFuture(IO(fut))
   def apply(impl: BitcoindInstance): BitcoindExtended = new BitcoindExtended(impl)
 }

--- a/demo-server/src/main/scala/co/topl/btc/server/bitcoin/BitcoindExtended.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/bitcoin/BitcoindExtended.scala
@@ -1,0 +1,35 @@
+package co.topl.btc.server.bitcoin
+
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.rpc.config.BitcoindInstance
+import play.api.libs.json.{JsArray, JsString, JsValue}
+import cats.effect.IO
+
+import scala.concurrent.Future
+
+final class BitcoindExtended(impl: BitcoindInstance) extends BitcoindRpcClient(impl){
+
+  implicit def futureToIO[T](fut: Future[T]): IO[T] = IO.fromFuture(IO(fut))
+
+  private def bitcoindCallRaw(
+    command:         String,
+    parameters:      List[JsValue] = List.empty,
+    uriExtensionOpt: Option[String] = None
+  ): Future[JsValue] = {
+    val request =
+      buildRequest(instance, command, JsArray(parameters), uriExtensionOpt)
+    val responseF = sendRequest(request)
+
+    val payloadF: Future[JsValue] =
+      responseF.flatMap(getPayload(_))
+
+    payloadF
+  }
+
+  def listWalletDirs(): IO[Seq[String]] = bitcoindCallRaw("listwalletdir")
+    .map(res => (res \ "result" \\ "name").map(_.as[String]).toSeq)
+}
+
+object BitcoindExtended {
+  def apply(impl: BitcoindInstance): BitcoindExtended = new BitcoindExtended(impl)
+}

--- a/demo-server/src/main/scala/co/topl/btc/server/bitcoin/Constants.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/bitcoin/Constants.scala
@@ -1,6 +1,0 @@
-package co.topl.btc.server.bitcoin
-
-object Constants {
-  val MintingWallet = "minting"
-  val DefaultWallet = "default"
-}

--- a/demo-server/src/main/scala/co/topl/btc/server/bitcoin/Constants.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/bitcoin/Constants.scala
@@ -1,0 +1,6 @@
+package co.topl.btc.server.bitcoin
+
+object Constants {
+  val MintingWallet = "minting"
+  val DefaultWallet = "default"
+}

--- a/demo-server/src/main/scala/co/topl/btc/server/bitcoin/Services.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/bitcoin/Services.scala
@@ -1,0 +1,13 @@
+package co.topl.btc.server.bitcoin
+
+import cats.effect.IO
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import Constants._
+
+object Services {
+  // Create or load wallets
+  def initializeWallets(bitcoind: BitcoindRpcClient): IO[Unit] = ???
+
+  // funds from minting wallet.. if minting wallet does not have enough, mint more
+  def fundWallet(bitcoind: BitcoindRpcClient): IO[Unit] = ???
+}

--- a/demo-server/src/main/scala/co/topl/btc/server/bitcoin/Services.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/bitcoin/Services.scala
@@ -53,4 +53,5 @@ object Services {
     _ <- fundMintingWallet(bitcoind)
     _ <- fundDefaultWallet(bitcoind)
   } yield println("Both Minting and Default wallets are funded")
+
 }

--- a/demo-server/src/main/scala/co/topl/btc/server/bitcoin/Services.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/bitcoin/Services.scala
@@ -1,13 +1,56 @@
 package co.topl.btc.server.bitcoin
 
 import cats.effect.IO
-import org.bitcoins.rpc.client.common.BitcoindRpcClient
-import Constants._
+import cats.implicits._
+import co.topl.btc.server.bitcoin.BitcoindExtended.futureToIO
+import org.bitcoins.core.currency.Bitcoins
 
 object Services {
-  // Create or load wallets
-  def initializeWallets(bitcoind: BitcoindRpcClient): IO[Unit] = ???
+  val MintingWallet = "minting"
+  val DefaultWallet = "default"
+  val minFunds = 50 // Minimum funds we want our default wallet to have
+  val InitialFunds = 1000 // To default wallet
+  val InitialBlocksToGenerate = 10000 // 10,000 should initialize the minting wallet with 495,000 BTC (arbitrary large number to avoid running out of funds)
+  val InitialFundsToMint = (InitialBlocksToGenerate - 100) * 50 // To minting wallet, 495,000 BTC
 
-  // funds from minting wallet.. if minting wallet does not have enough, mint more
-  def fundWallet(bitcoind: BitcoindRpcClient): IO[Unit] = ???
+  // Create or load wallets
+  def initializeWallets(bitcoind: BitcoindExtended): IO[Unit] = for {
+    allWallets <- bitcoind.listWalletDirs()
+    _ <- if(allWallets.contains(MintingWallet)) IO.unit else futureToIO(bitcoind.createWallet(MintingWallet))
+    _ <- if(allWallets.contains(DefaultWallet)) IO.unit else futureToIO(bitcoind.createWallet(DefaultWallet))
+    loadedWallets <- futureToIO(bitcoind.listWallets)
+    unloadedWallets = allWallets.filterNot(loadedWallets.contains)
+    res <- unloadedWallets.map(bitcoind.loadWallet).map(futureToIO).sequence
+  } yield println("All wallets are loaded: " + allWallets.mkString(", "))
+
+  // Only valid for RegTest
+  private def fundMintingWallet(bitcoind: BitcoindExtended): IO[Unit] = for {
+    currentBalance <- futureToIO(bitcoind.getBalance(MintingWallet))
+    needsFunding = currentBalance.toBigDecimal <= BigDecimal(InitialFunds)
+    newBalance <- if(needsFunding) for {
+      addr <- futureToIO(bitcoind.getNewAddress(MintingWallet))
+      // If Minting wallet does not have enough for the default wallet, load the minting wallet with a large amount of funds
+      _ <- futureToIO(bitcoind.generateToAddress(InitialFunds, addr))
+      balRes <- futureToIO(bitcoind.getBalance(MintingWallet)).iterateUntil(_.toBigDecimal >= BigDecimal(InitialFundsToMint))
+    } yield balRes
+     else IO.pure(currentBalance)
+  } yield println("Minting wallet funded: " + newBalance)
+
+  private def fundDefaultWallet(bitcoind: BitcoindExtended): IO[Unit] = for {
+    currentBalance <- futureToIO(bitcoind.getBalance(DefaultWallet))
+    needsFunding = currentBalance.toBigDecimal <= BigDecimal(minFunds)
+    newBalance <- if(needsFunding) for {
+      addr <- futureToIO(bitcoind.getNewAddress(DefaultWallet))
+      // If Default wallet does not have enough, transfer funds from minting wallet
+      _ <- futureToIO(bitcoind.sendToAddress(addr, Bitcoins(InitialFunds), walletNameOpt = Some(MintingWallet)))
+      balRes <- futureToIO(bitcoind.getBalance(DefaultWallet)).iterateUntil(_.toBigDecimal >= BigDecimal(InitialFunds))
+    } yield balRes
+     else IO.pure(currentBalance)
+  } yield println("Default wallet funded: " + newBalance)
+
+  // Fund default wallet. Preconditions: Both wallets are loaded
+  def fundWallets(bitcoind: BitcoindExtended): IO[Unit] = for {
+    _ <- fundMintingWallet(bitcoind)
+    _ <- fundDefaultWallet(bitcoind)
+  } yield println("Both Minting and Default wallets are funded")
 }

--- a/demo-server/src/main/scala/co/topl/btc/server/bitcoin/package.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/bitcoin/package.scala
@@ -4,8 +4,10 @@ import akka.actor.ActorSystem
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.rpc.config.{BitcoindAuthCredentials, BitcoindInstanceLocal, BitcoindInstanceRemote}
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.rpc.config.BitcoindInstance
 import org.bitcoins.tor.Socks5ProxyParams
 import cats.effect.IO
+import co.topl.btc.server.bitcoin.BitcoindExtended
 
 import java.io.File
 import java.net.URI
@@ -26,7 +28,7 @@ package object bitcoin {
       host:        String,
       credentials: BitcoindAuthCredentials,
       binary:      File
-    ): BitcoindRpcClient = BitcoindRpcClient(
+    ): BitcoindExtended = BitcoindExtended(
       BitcoindInstanceLocal(
         network = network,
         uri = new URI(s"$host:${network.port}"),
@@ -50,7 +52,7 @@ package object bitcoin {
       host:        String,
       credentials: BitcoindAuthCredentials,
       proxyParams: Option[Socks5ProxyParams] = None
-    ): BitcoindRpcClient = BitcoindRpcClient(
+    ): BitcoindExtended = BitcoindExtended(
       BitcoindInstanceRemote(
         network = network,
         uri = new URI(s"$host:${network.port}"),
@@ -60,5 +62,5 @@ package object bitcoin {
       )
     )
 
-    def onStartup(bitcoind: BitcoindRpcClient): IO[Unit] = ???
+    def onStartup(bitcoind: BitcoindExtended): IO[Unit] = ???
 }

--- a/demo-server/src/main/scala/co/topl/btc/server/bitcoin/package.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/bitcoin/package.scala
@@ -8,6 +8,7 @@ import org.bitcoins.rpc.config.BitcoindInstance
 import org.bitcoins.tor.Socks5ProxyParams
 import cats.effect.IO
 import co.topl.btc.server.bitcoin.BitcoindExtended
+import co.topl.btc.server.bitcoin.Services.{initializeWallets, fundWallets}
 
 import java.io.File
 import java.net.URI
@@ -62,5 +63,8 @@ package object bitcoin {
       )
     )
 
-    def onStartup(bitcoind: BitcoindExtended): IO[Unit] = ???
+    def onStartup(bitcoind: BitcoindExtended): IO[Unit] = for {
+      _ <- initializeWallets(bitcoind)
+      _ <- fundWallets(bitcoind)
+    } yield println("Bitcoind start-up complete.")
 }

--- a/demo-server/src/main/scala/co/topl/btc/server/bitcoin/package.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/bitcoin/package.scala
@@ -1,0 +1,64 @@
+package co.topl.btc.server
+
+import akka.actor.ActorSystem
+import org.bitcoins.core.config.NetworkParameters
+import org.bitcoins.rpc.config.{BitcoindAuthCredentials, BitcoindInstanceLocal, BitcoindInstanceRemote}
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.tor.Socks5ProxyParams
+import cats.effect.IO
+
+import java.io.File
+import java.net.URI
+
+package object bitcoin {
+    implicit val system: ActorSystem = ActorSystem("System")
+
+      /**
+     * Connection to the bitcoind RPC server instance
+     * @param network Parameters of a given network to be used
+     * @param host The host to connect to the bitcoind instance
+     * @param credentials rpc credentials
+     * @param binary the bitcoind executable
+     * @return
+     */
+    def localConnection(
+      network:     NetworkParameters,
+      host:        String,
+      credentials: BitcoindAuthCredentials,
+      binary:      File
+    ): BitcoindRpcClient = BitcoindRpcClient(
+      BitcoindInstanceLocal(
+        network = network,
+        uri = new URI(s"$host:${network.port}"),
+        rpcUri = new URI(s"$host:${network.rpcPort}"),
+        authCredentials = credentials,
+        binary = binary
+      )
+    )
+
+    /**
+     * Connection to the bitcoind RPC server instance
+     *
+     * @param network     Parameters of a given network to be used
+     * @param host        The host to connect to the bitcoind instance
+     * @param credentials rpc credentials
+     * @param proxyParams proxy parameters
+     * @return
+     */
+    def remoteConnection(
+      network:     NetworkParameters,
+      host:        String,
+      credentials: BitcoindAuthCredentials,
+      proxyParams: Option[Socks5ProxyParams] = None
+    ): BitcoindRpcClient = BitcoindRpcClient(
+      BitcoindInstanceRemote(
+        network = network,
+        uri = new URI(s"$host:${network.port}"),
+        rpcUri = new URI(s"$host:${network.rpcPort}"),
+        authCredentials = credentials,
+        proxyParams = proxyParams
+      )
+    )
+
+    def onStartup(bitcoind: BitcoindRpcClient): IO[Unit] = ???
+}


### PR DESCRIPTION
## Purpose

Connect backend to bitcoind

## Approach

- Added bitcoin-s
    - Connected to bitcoind via Remote Instance (configurable host, user, and password)
- On server start-up, initialize wallets (minting wallet and default wallet)
    - default wallet has 100 BTC
    - Using scopt to parse parameters (rpc username and password) 
- connected the API endpoint to bitcoind
    - Added Json decoder for the Transfer request 
- changed port from 3000 to 3002

## Testing

- Manual testing

## Tickets
* Closes TSDK-779