### PR TITLE
TSDK-784 Integrate with Bridge WS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initialized the front end for the demo application
 - Initialized the back end for the demo application
 - Connected backend to bitcoind
+- Call bridge WS when peg-in funds are deposited

--- a/demo-server/src/main/scala/co/topl/btc/server/Params.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/Params.scala
@@ -5,7 +5,9 @@ import scopt.OParser
 final case class Params(
   bitcoindUrl: String = "http://localhost", 
   bitcoindUser: String = "", 
-  bitcoindPassword: String = ""
+  bitcoindPassword: String = "",
+  bridgeUrl: String = "http://localhost",
+  bridgePort: Int = 4000
 )
 
 object Params {
@@ -30,7 +32,17 @@ object Params {
         .action((x, c) => c.copy(bitcoindPassword = x))
         .text(
           "The password to connect to a bitcoind instance. (required)"
-        )
+        ),
+      opt[String]("bridge-url")
+        .action((x, c) => c.copy(bitcoindUrl = x))
+        .text(
+          "The URL to connect to a bridge WS instance. (default: http://localhost)"
+        ),
+      opt[String]("bridge-port")
+        .action((x, c) => c.copy(bitcoindUrl = x))
+        .text(
+          "The port to connect to a bridge WS instance. (default: 4000)"
+        ),
     )
   }
 

--- a/demo-server/src/main/scala/co/topl/btc/server/api/TransferRequest.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/api/TransferRequest.scala
@@ -36,7 +36,6 @@ object TransferRequest {
           quantity <- c.downField("quantity").as[Int]
           transferType <- c.downField("transferType").as[String]
           pegInOpts <- transferType match {
-            //Look how you did it for the vault 
             case "peginDeposit" => c.downField("pegInOptions").downField("sessionId").as[String].map(sId => Some(PegInOpts(sId)))
             case _ => Right(None)
           }

--- a/demo-server/src/main/scala/co/topl/btc/server/api/TransferRequest.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/api/TransferRequest.scala
@@ -13,14 +13,17 @@ import org.bitcoins.core.currency.Satoshis
 import co.topl.btc.server.bitcoin.BitcoindExtended
 import co.topl.btc.server.bitcoin.Services.MintingWallet
 import co.topl.btc.server.bitcoin.BitcoindExtended.futureToIO
+import TransferRequest.PegInOpts
+import io.circe.Json
 
 /**
   * A case class representing a BTC transfer request
   */
-case class TransferRequest(fromWallet: String, toAddress: BitcoinAddress, quantity: Satoshis)
+case class TransferRequest(fromWallet: String, toAddress: BitcoinAddress, quantity: Satoshis, pegInOpts: Option[PegInOpts] = None)
 
 
 object TransferRequest {
+  case class PegInOpts(sessionID: String)
 
     /**
       * A Circe JSON decoders for the transfer request
@@ -31,7 +34,13 @@ object TransferRequest {
           fromWallet <- c.downField("fromWallet").as[String]
           toAddress <- c.downField("toAddress").as[String]
           quantity <- c.downField("quantity").as[Int]
-        } yield TransferRequest(fromWallet, BitcoinAddress(toAddress), Satoshis(quantity))
+          transferType <- c.downField("transferType").as[String]
+          pegInOpts <- transferType match {
+            //Look how you did it for the vault 
+            case "peginDeposit" => c.downField("pegInOptions").downField("sessionId").as[String].map(sId => Some(PegInOpts(sId)))
+            case _ => Right(None)
+          }
+        } yield TransferRequest(fromWallet, BitcoinAddress(toAddress), Satoshis(quantity), pegInOpts)
     }
     implicit val decoder: EntityDecoder[IO, TransferRequest] = jsonOf[IO, TransferRequest]
 
@@ -42,13 +51,29 @@ object TransferRequest {
       * @param bitcoind The bitcoind instance to use
       * @return An IO monad containing the response
       */
-    def handler(r: Request[IO], bitcoind: BitcoindExtended): IO[Response[IO]] = for {
-      req <- r.as[TransferRequest]
+    def handler(r: Request[IO], bitcoind: BitcoindExtended, notifyPegInDeposit: ConfirmDepositRequest => IO[Unit]): IO[Response[IO]] = for {
+      req <- {
+        println("a")
+        val x = r.as[TransferRequest]
+        println("b")
+        x
+      }
       txId <- bitcoind.sendToAddressWithFees(req.toAddress, req.quantity, req.fromWallet)
       // Manually mint a new block.. will be removed in the future
       mintAddr <- futureToIO(bitcoind.getNewAddress(walletNameOpt = Some(MintingWallet)))
       _ <- futureToIO(bitcoind.generateToAddress(1, mintAddr))
-      resp <- Ok(txId.hex)
+      temp <- {
+        println("ahhh")
+        req.pegInOpts match {
+        case Some(opts) => notifyPegInDeposit(ConfirmDepositRequest(opts.sessionID, req.quantity.satoshis.toLong)).start.void
+        case None => IO.unit
+      }
+    }
+      resp <- {
+        println("oop")
+        println(temp)
+        Ok(txId.hex)
+      }
     } yield resp
 
 }

--- a/demo-server/src/main/scala/co/topl/btc/server/api/package.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/api/package.scala
@@ -1,14 +1,49 @@
 package co.topl.btc.server
 
-import org.http4s.HttpRoutes
-import org.http4s.dsl.io._
 import cats.effect.IO
 import co.topl.btc.server.bitcoin.BitcoindExtended
+import cats.effect.kernel.Resource
+import org.http4s.client.Client
+import org.http4s.implicits._
+import io.circe.generic.auto._
+import io.circe.Json
+import io.circe.syntax._
+import org.http4s._
+import org.http4s.Uri._
+import org.http4s.circe._
+import org.http4s.dsl.io._
+import org.http4s.EntityEncoder
+
 
 package object api {
+  case class BridgeWSClient(wsUrl: String, client: Resource[IO, Client[IO]])
+  case class ConfirmDepositRequest(sessionID: String, amount: Long)
+  case class ConfirmDepositResponse(
+    txId: String,
+    redeemAddress: String
+)
+
+  implicit val reqDecoder: EntityDecoder[IO, ConfirmDepositRequest] = jsonOf[IO, ConfirmDepositRequest]
+  implicit val resDecoder: EntityDecoder[IO, ConfirmDepositResponse] = jsonOf[IO, ConfirmDepositResponse]
+
+  import cats.effect.unsafe.implicits.global
+
+  def comfirmPegInDeposit(ws: BridgeWSClient): ConfirmDepositRequest => IO[Unit] = (depositReq: ConfirmDepositRequest) =>
+{    ws.client.use(client => client.status({
+  println("here")
+      println(depositReq.asJson)
+      val x = Request[IO](method = Method.POST, uri = Uri(Some(Scheme.http), Some(Authority(port= Some(4000))), Root / "api"/ "confirm-deposit-btc")).withEntity(depositReq.asJson)
+      println(x)
+      x
+    }
+    ).flatMap(IO.println(_))
+  )}
 
   // Define the API service routes
-  def apiService(bitcoind: BitcoindExtended): HttpRoutes[IO] = HttpRoutes.of[IO] {
-    case r @ POST -> Root / "transfer" => TransferRequest.handler(r, bitcoind)
+  def apiService(bitcoind: BitcoindExtended, wsClient: BridgeWSClient): HttpRoutes[IO] = HttpRoutes.of[IO] {
+    case r @ POST -> Root / "transfer" => {
+      println("why")
+      TransferRequest.handler(r, bitcoind, comfirmPegInDeposit(wsClient))
+    }
   }
 }

--- a/demo-server/src/main/scala/co/topl/btc/server/api/package.scala
+++ b/demo-server/src/main/scala/co/topl/btc/server/api/package.scala
@@ -18,32 +18,19 @@ import org.http4s.EntityEncoder
 package object api {
   case class BridgeWSClient(wsUrl: String, client: Resource[IO, Client[IO]])
   case class ConfirmDepositRequest(sessionID: String, amount: Long)
-  case class ConfirmDepositResponse(
-    txId: String,
-    redeemAddress: String
-)
 
   implicit val reqDecoder: EntityDecoder[IO, ConfirmDepositRequest] = jsonOf[IO, ConfirmDepositRequest]
-  implicit val resDecoder: EntityDecoder[IO, ConfirmDepositResponse] = jsonOf[IO, ConfirmDepositResponse]
 
   import cats.effect.unsafe.implicits.global
 
   def comfirmPegInDeposit(ws: BridgeWSClient): ConfirmDepositRequest => IO[Unit] = (depositReq: ConfirmDepositRequest) =>
-{    ws.client.use(client => client.status({
-  println("here")
-      println(depositReq.asJson)
-      val x = Request[IO](method = Method.POST, uri = Uri(Some(Scheme.http), Some(Authority(port= Some(4000))), Root / "api"/ "confirm-deposit-btc")).withEntity(depositReq.asJson)
-      println(x)
-      x
-    }
-    ).flatMap(IO.println(_))
-  )}
+    ws.client.use(client => 
+      client.status(
+        Request[IO](method = Method.POST, uri = Uri(Some(Scheme.http), Some(Authority(port= Some(4000))), Root / "api"/ "confirm-deposit-btc")).withEntity(depositReq.asJson)
+      ).flatMap(status => IO.println(s"confirm deposit status: $status")))
 
   // Define the API service routes
   def apiService(bitcoind: BitcoindExtended, wsClient: BridgeWSClient): HttpRoutes[IO] = HttpRoutes.of[IO] {
-    case r @ POST -> Root / "transfer" => {
-      println("why")
-      TransferRequest.handler(r, bitcoind, comfirmPegInDeposit(wsClient))
-    }
+    case r @ POST -> Root / "transfer" => TransferRequest.handler(r, bitcoind, comfirmPegInDeposit(wsClient))
   }
 }

--- a/demo-ui/src/services/submitTransfer.ts
+++ b/demo-ui/src/services/submitTransfer.ts
@@ -3,7 +3,13 @@ import axios from "axios"
 interface TransferData {
     fromWallet: string
     toAddress: string
-    quantity: bigint
+    quantity: bigint,
+    transferType: String,
+    pegInOptions?: PegInOptions
+}
+
+interface PegInOptions {
+    sessionId: String
 }
 
 const submitTransfer = async (data: TransferData) => {

--- a/demo-ui/src/views/Transfer.tsx
+++ b/demo-ui/src/views/Transfer.tsx
@@ -62,21 +62,6 @@ const Transfer: FunctionComponent =  () => {
               The wallet where the BTC will be sent from.
             </Form.Text>
           </Form.Group>
-          <Form.Group className="mb-3" controlId="recipientAddress">
-            <Form.Label>Recipient Address</Form.Label>
-            <Form.Control type="text" placeholder="bcrt1q58..." name='toAddress' required/>
-            <Form.Text className="text-muted">
-              The address to send BTC to.
-            </Form.Text>
-          </Form.Group>
-
-          <Form.Group className="mb-3" controlId="transferAmount">
-            <Form.Label>Quantity</Form.Label>
-            <Form.Control type="number" placeholder="1234" name='quantity' min={0} required/>
-            <Form.Text className="text-muted">
-              The amount of BTC to send to the recipient in Satoshis. 1 BTC = 100,000,000 Satoshis.
-            </Form.Text>
-          </Form.Group>
           <Form.Check className="mb-3">
             <Form.Label>Bridge Transfer Type</Form.Label>
             <div>
@@ -108,6 +93,21 @@ const Transfer: FunctionComponent =  () => {
           {
             transferType === "peginDeposit" ? <PegInOptions/> : <PegOutOptions/>
           }
+          <Form.Group className="mb-3" controlId="recipientAddress">
+            <Form.Label>Recipient Address</Form.Label>
+            <Form.Control type="text" placeholder="bcrt1q58..." name='toAddress' required/>
+            <Form.Text className="text-muted">
+              The address to send BTC to.
+            </Form.Text>
+          </Form.Group>
+
+          <Form.Group className="mb-3" controlId="transferAmount">
+            <Form.Label>Quantity</Form.Label>
+            <Form.Control type="number" placeholder="1234" name='quantity' min={0} required/>
+            <Form.Text className="text-muted">
+              The amount of BTC to send to the recipient in Satoshis. 1 BTC = 100,000,000 Satoshis.
+            </Form.Text>
+          </Form.Group>
           <Button variant="primary" type="submit">
             Send
           </Button>

--- a/demo-ui/src/views/Transfer.tsx
+++ b/demo-ui/src/views/Transfer.tsx
@@ -5,6 +5,7 @@ import Card from 'react-bootstrap/Card';
 import { FormEventHandler } from 'react';
 import submitTransfer from '../services/submitTransfer';
 import { toast } from 'react-toastify';
+import { useState } from 'react';
 
 const handleSubmit: FormEventHandler<HTMLFormElement> = event => {
   event.preventDefault();
@@ -14,6 +15,8 @@ const handleSubmit: FormEventHandler<HTMLFormElement> = event => {
     fromWallet: formData.get('fromWallet') as string,
     toAddress: formData.get('toAddress') as string,
     quantity: BigInt(formData.get('quantity') as string),
+    transferType: formData.get('transferType') as string,
+    pegInOptions: {sessionId: formData.get('sessionId') as string},
   }), {
     pending: "Submitting transfer request...",
     success: "Transfer request submitted successfully",
@@ -22,11 +25,33 @@ const handleSubmit: FormEventHandler<HTMLFormElement> = event => {
   .then(() => form.reset(), () => {})
 }
 
+const PegInOptions: FunctionComponent = () => {
+  return <div>
+    <Form.Group className="mb-3" controlId="sessionId">
+      <Form.Label>Session ID</Form.Label>
+      <Form.Control type="text" placeholder="1234" name='sessionId' required/>
+      <Form.Text className="text-muted">
+        The ID of the bridge session for which this peg-in deposit is being made.
+      </Form.Text>
+    </Form.Group>
+  </div>
+}
+
+const PegOutOptions: FunctionComponent = () => {
+  return <div>
+    <Form.Text className="text-muted">
+      Additional options for a Peg-out redemption transfer.
+    </Form.Text>
+  </div>
+}
+
 const Transfer: FunctionComponent =  () => {
+  const [transferType, setTransferType] = useState<string>("peginDeposit")
+
   return <div>
     <h1 className='py-4 text-center'>Transfer BTC</h1>
     <Card className='w-1/2 m-auto'>
-      <Card.Header className='!bg-slate-100'>Transfer BTC for Peg-in from default local wallet</Card.Header>
+      <Card.Header className='!bg-slate-100'>Transfer BTC from default local wallet</Card.Header>
       <Card.Body>
         <Form onSubmit={handleSubmit}>
           <Form.Group className="mb-3" controlId="walletName" hidden>
@@ -52,6 +77,37 @@ const Transfer: FunctionComponent =  () => {
               The amount of BTC to send to the recipient in Satoshis. 1 BTC = 100,000,000 Satoshis.
             </Form.Text>
           </Form.Group>
+          <Form.Check className="mb-3">
+            <Form.Label>Bridge Transfer Type</Form.Label>
+            <div>
+              <Form.Check
+                inline
+                required
+                className='cursor-none pointer-events-none'
+                type="radio"
+                label="Pegin Deposit"
+                id="peginDeposit"
+                name='transferType'
+                value="peginDeposit"
+                defaultChecked={transferType === "peginDeposit"}
+                onChange={(e) => setTransferType(e.target.id)}
+              />
+              <Form.Check
+                inline
+                hidden
+                type="radio"
+                // label="Pegout Redeem"
+                id="pegoutRedeem"
+                name='transferType'
+                value="pegoutRedeem"
+                defaultChecked={transferType === "pegoutRedeem"}
+                onChange={(e) => setTransferType(e.target.id)}
+              />
+            </div>
+          </Form.Check>
+          {
+            transferType === "peginDeposit" ? <PegInOptions/> : <PegOutOptions/>
+          }
           <Button variant="primary" type="submit">
             Send
           </Button>


### PR DESCRIPTION
## Purpose

To integrate with the Bridge WS so the user does not have to explicitly click "Funds sent" when they transfer BTC for peg-in deposit

## Approach

- Added "sessionId" form field to the btc transfer form
- Added params to the Demo BTC Wallet server for URL and port to connect to bridge WS
- After a Peg-in deposit (as specified by one of the form fields), the server calls the WS to notify that the funds have been sent 

## Testing

Manually tested

## Tickets
* TSDK-784